### PR TITLE
Make type Client visible to user

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-type client struct {
+type Client struct {
 	ws                 *websocket.Conn
 	Events             chan *Event
 	Stop               chan bool
@@ -18,7 +18,7 @@ type client struct {
 }
 
 // heartbeat send a ping frame to server each - TODO reconnect on disconnect
-func (c *client) heartbeat() {
+func (c *Client) heartbeat() {
 	for {
 		websocket.Message.Send(c.ws, `{"event":"pusher:ping","data":"{}"}`)
 		time.Sleep(HEARTBEAT_RATE * time.Second)
@@ -26,7 +26,7 @@ func (c *client) heartbeat() {
 }
 
 // listen to Pusher server and process/dispatch recieved events
-func (c *client) listen() {
+func (c *Client) listen() {
 	for {
 		var event Event
 		err := websocket.JSON.Receive(c.ws, &event)
@@ -51,7 +51,7 @@ func (c *client) listen() {
 }
 
 // Subsribe to a channel
-func (c *client) Subscribe(channel string) (err error) {
+func (c *Client) Subscribe(channel string) (err error) {
 	// Already subscribed ?
 	if c.subscribedChannels.contains(channel) {
 		err = errors.New(fmt.Sprintf("Channel %s already subscribed", channel))
@@ -66,7 +66,7 @@ func (c *client) Subscribe(channel string) (err error) {
 }
 
 // Unsubscribe from a channel
-func (c *client) Unsubscribe(channel string) (err error) {
+func (c *Client) Unsubscribe(channel string) (err error) {
 	// subscribed ?
 	if !c.subscribedChannels.contains(channel) {
 		err = errors.New(fmt.Sprintf("Client isn't subscrived to %s", channel))
@@ -82,7 +82,7 @@ func (c *client) Unsubscribe(channel string) (err error) {
 }
 
 // Bind an event
-func (c *client) Bind(evt string) (dataChannel chan *Event, err error) {
+func (c *Client) Bind(evt string) (dataChannel chan *Event, err error) {
 	// Already binded
 	_, ok := c.binders[evt]
 	if ok {
@@ -96,11 +96,11 @@ func (c *client) Bind(evt string) (dataChannel chan *Event, err error) {
 }
 
 // Unbind a event
-func (c *client) Unbind(evt string) {
+func (c *Client) Unbind(evt string) {
 	delete(c.binders, evt)
 }
 
-func NewCustomClient(appKey, host, scheme string) (*client, error) {
+func NewCustomClient(appKey, host, scheme string) (*Client, error) {
 	origin := "http://localhost/"
 	url := scheme + "://" + host + "/app/" + appKey + "?protocol=" + PROTOCOL_VERSION
 	ws, err := websocket.Dial(url, "", origin)
@@ -138,6 +138,6 @@ func NewCustomClient(appKey, host, scheme string) (*client, error) {
 }
 
 // NewClient initialize & return a Pusher client
-func NewClient(appKey string) (*client, error) {
+func NewClient(appKey string) (*Client, error) {
 	return NewCustomClient(appKey, "ws.pusherapp.com:443", "wss")
 }


### PR DESCRIPTION
Export Client type so it can be saved within other types for future usage.
