### PR TITLE
Unmarshal errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -118,20 +118,19 @@ func NewCustomClient(appKey, host, scheme string) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	var event Event
-	err = json.Unmarshal(resp[0:n], &event)
+	var eventStub EventStub
+	err = json.Unmarshal(resp[0:n], &eventStub)
 	if err != nil {
 		return nil, err
 	}
-	switch event.Event {
+	switch eventStub.Event {
 	case "pusher:error":
-		var data eventError
-		err = json.Unmarshal([]byte(event.Data), &data)
+		var ewe EventError
+		err = json.Unmarshal(resp[0:n], &ewe)
 		if err != nil {
 			return nil, err
 		}
-		err = errors.New(fmt.Sprintf("Pusher return error : code : %d, message %s", data.code, data.message))
-		return nil, err
+		return nil, ewe
 	case "pusher:connection_established":
 		sChannels := new(subscribedChannels)
 		sChannels.channels = make([]string, 0)

--- a/event.go
+++ b/event.go
@@ -1,12 +1,28 @@
 package pusher
 
+import "fmt"
+
+// EventStub contains just the "type" of event.
+// Knowing the type, we can then unmarshal again, into appropriate type.
+type EventStub struct {
+	Event string `json:"event"`
+}
+
 type Event struct {
 	Event string `json:"event"`
 	Data  string `json:"data"`
 }
 
-// eventError represent a pusher:error data
-type eventError struct {
-	message string `json:"message"`
-	code    int    `json:"code"`
+// EventError contains a structured error in its Data field.
+// It implements error.
+type EventError struct {
+	Event string `json:"event"`
+	Data  struct {
+		Message string `json:"message"`
+		Code    int    `json:"code"`
+	} `json:"data"`
+}
+
+func (ewe EventError) Error() string {
+	return fmt.Sprintf("Pusher return error: code %d, message %q", ewe.Data.Code, ewe.Data.Message)
 }


### PR DESCRIPTION
Exceeding my Pusher quota yielded error `json: cannot unmarshal object into Go struct field Event.data of type string`.

Some problems prevented the go-pusher lib to correctly report errors, because it is non-trivial to expect  a "polymorph" JSON event object and unmarshal it correctly in each case.

Now the error object stringifies to `Pusher return error: code 4004, message "Account over quota"`.
The normal case (on no quota exceeded) still works in my program, but I didn't check for all possible regressions.