### PR TITLE
Added Channel field to Event

### DIFF
--- a/event.go
+++ b/event.go
@@ -11,6 +11,7 @@ type EventStub struct {
 type Event struct {
 	Event string `json:"event"`
 	Data  string `json:"data"`
+	Channel string `json:"channel"`
 }
 
 // EventError contains a structured error in its Data field.


### PR DESCRIPTION
When subscribing to multiple channels with the same event name, channel name in an emitted message from each channel is useful to determine the origin of that message. In Bitstamp case if one tries to listen to multiple channels at the same time (arbitrage bot), events with the same name cannot tell us for which market they were emitted (data for orders, trades for trades...). Adding Channel field to Event struct solves the problem.